### PR TITLE
[enhancement] bumped dependency + plugin versions. change h2 profile

### DIFF
--- a/performance-tests/pom.xml
+++ b/performance-tests/pom.xml
@@ -35,9 +35,9 @@
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
         <version.java>1.7</version.java>
 
-        <version.org.springframework>4.0.0.RELEASE</version.org.springframework>
-        <version.com.h2database>1.3.170</version.com.h2database>
-        <version.postgresql>9.1-901.jdbc4</version.postgresql>
+        <version.org.springframework>4.0.2.RELEASE</version.org.springframework>
+        <version.com.h2database>1.3.175</version.com.h2database>
+        <version.postgresql>9.3-1101-jdbc41</version.postgresql>
 
         <!-- OSIAM -->
         <version.org.osiam.server>0.19-SNAPSHOT</version.org.osiam.server>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.5</version>
+            <version>1.7.6</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -111,7 +111,7 @@
 
         <!-- Running tests in IDE -->
         <profile>
-            <id>ide</id>
+            <id>ide-h2</id>
             <properties>
                 <osiam.properties.file>osiam_h2.properties</osiam.properties.file>
             </properties>
@@ -170,7 +170,7 @@
 
             <dependencies>
                 <dependency>
-                    <groupId>postgresql</groupId>
+                    <groupId>org.postgresql</groupId>
                     <artifactId>postgresql</artifactId>
                     <version>${version.postgresql}</version>
                 </dependency>
@@ -198,7 +198,7 @@
                         <artifactId>jetty-maven-plugin</artifactId>
                         <dependencies>
                             <dependency>
-                                <groupId>postgresql</groupId>
+                                <groupId>org.postgresql</groupId>
                                 <artifactId>postgresql</artifactId>
                                 <version>${version.postgresql}</version>
                             </dependency>
@@ -451,7 +451,7 @@
 
             <dependencies>
                 <dependency>
-                    <groupId>postgresql</groupId>
+                    <groupId>org.postgresql</groupId>
                     <artifactId>postgresql</artifactId>
                     <version>${version.postgresql}</version>
                 </dependency>
@@ -478,7 +478,7 @@
                         <artifactId>jetty-maven-plugin</artifactId>
                         <dependencies>
                             <dependency>
-                                <groupId>postgresql</groupId>
+                                <groupId>org.postgresql</groupId>
                                 <artifactId>postgresql</artifactId>
                                 <version>${version.postgresql}</version>
                             </dependency>
@@ -625,7 +625,7 @@
                 <plugin>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
-                    <version>9.1.1.v20140108</version>
+                    <version>9.1.3.v20140225</version>
                     <configuration>
                         <requestLog implementation="org.eclipse.jetty.server.NCSARequestLog">
                             <filename>target/yyyy_mm_dd.request.log</filename>
@@ -672,7 +672,7 @@
                 <plugin>
                     <groupId>com.lazerycode.jmeter</groupId>
                     <artifactId>jmeter-maven-plugin</artifactId>
-                    <version>1.8.1</version>
+                    <version>1.9.0</version>
                     <executions>
                         <execution>
                             <id>jmeter-tests</id>


### PR DESCRIPTION
now the performance tests with a h2 database must be start with the following command:
mvn jetty:run -P ide-h2
